### PR TITLE
Feat/submit form

### DIFF
--- a/__tests__/inspectionForm.test.ts
+++ b/__tests__/inspectionForm.test.ts
@@ -4,18 +4,21 @@ import {
   getTaskStatusForInspectionAction,
   initialInspectionChecklist,
   isInspectionChecklistComplete,
-  normaliseEngineerInitials,
+  isValidEmployeeNumber,
+  normaliseEmployeeNumber,
   updateTaskStatusForInspectionAction,
   upsertInspectionDraft,
 } from '../src/utils/inspectionForm';
 
 describe('inspection form helpers', () => {
-  it('normalises engineer initials to trimmed uppercase text', () => {
-    expect(normaliseEngineerInitials(' jc ')).toBe('JC');
+  it('normalises employee numbers to digits only with a four-digit maximum', () => {
+    expect(normaliseEmployeeNumber(' 12a34 56 ')).toBe('1234');
   });
 
-  it('returns a placeholder when initials are empty', () => {
-    expect(normaliseEngineerInitials('   ')).toBe('Not set');
+  it('accepts only valid four-digit employee numbers', () => {
+    expect(isValidEmployeeNumber('1234')).toBe(true);
+    expect(isValidEmployeeNumber('123')).toBe(false);
+    expect(isValidEmployeeNumber('12a4')).toBe(false);
   });
 
   it('treats the checklist as incomplete until every item is true', () => {
@@ -32,7 +35,7 @@ describe('inspection form helpers', () => {
   it('builds a draft summary with trimmed notes length and checklist state', () => {
     expect(
       buildInspectionDraftSummary({
-        engineerInitials: 'ab',
+        employeeNumber: '12a45',
         condition: 'monitor',
         notes: '  follow up required  ',
         checklist: {
@@ -42,7 +45,8 @@ describe('inspection form helpers', () => {
         },
       }),
     ).toEqual({
-      engineerInitials: 'AB',
+      employeeNumber: '1245',
+      employeeNumberValid: true,
       condition: 'monitor',
       notesLength: 18,
       checklistComplete: false,
@@ -60,7 +64,7 @@ describe('inspection form helpers', () => {
         },
         'task-2',
         {
-          engineerInitials: 'jc',
+          employeeNumber: '12a4',
           condition: 'pass',
           notes: 'new draft',
           checklist: {
@@ -76,7 +80,7 @@ describe('inspection form helpers', () => {
         notes: 'existing',
       },
       'task-2': {
-        engineerInitials: 'jc',
+        employeeNumber: '124',
         condition: 'pass',
         notes: 'new draft',
         checklist: {

--- a/__tests__/inspectionForm.test.ts
+++ b/__tests__/inspectionForm.test.ts
@@ -1,8 +1,12 @@
 import {
   buildInspectionDraftSummary,
+  emptyInspectionDraft,
+  getTaskStatusForInspectionAction,
   initialInspectionChecklist,
   isInspectionChecklistComplete,
   normaliseEngineerInitials,
+  updateTaskStatusForInspectionAction,
+  upsertInspectionDraft,
 } from '../src/utils/inspectionForm';
 
 describe('inspection form helpers', () => {
@@ -43,5 +47,101 @@ describe('inspection form helpers', () => {
       notesLength: 18,
       checklistComplete: false,
     });
+  });
+
+  it('stores drafts by task id without mutating other saved drafts', () => {
+    expect(
+      upsertInspectionDraft(
+        {
+          'task-1': {
+            ...emptyInspectionDraft,
+            notes: 'existing',
+          },
+        },
+        'task-2',
+        {
+          engineerInitials: 'jc',
+          condition: 'pass',
+          notes: 'new draft',
+          checklist: {
+            safeIsolation: true,
+            structuralIntegrity: false,
+            leakCheck: false,
+          },
+        },
+      ),
+    ).toEqual({
+      'task-1': {
+        ...emptyInspectionDraft,
+        notes: 'existing',
+      },
+      'task-2': {
+        engineerInitials: 'jc',
+        condition: 'pass',
+        notes: 'new draft',
+        checklist: {
+          safeIsolation: true,
+          structuralIntegrity: false,
+          leakCheck: false,
+        },
+      },
+    });
+  });
+
+  it('maps inspection actions to the expected task status', () => {
+    expect(getTaskStatusForInspectionAction('save-draft')).toBe('in-progress');
+    expect(getTaskStatusForInspectionAction('complete')).toBe('complete');
+  });
+
+  it('updates only the selected task status when an inspection is submitted', () => {
+    expect(
+      updateTaskStatusForInspectionAction(
+        [
+          {
+            id: 'task-1',
+            assetId: 'asset-1',
+            assetName: 'Asset 1',
+            siteName: 'Site 1',
+            dueDate: '2026-05-04T10:00:00.000Z',
+            priority: 'high',
+            status: 'pending',
+            summary: 'Summary 1',
+          },
+          {
+            id: 'task-2',
+            assetId: 'asset-2',
+            assetName: 'Asset 2',
+            siteName: 'Site 2',
+            dueDate: '2026-05-05T10:00:00.000Z',
+            priority: 'low',
+            status: 'pending',
+            summary: 'Summary 2',
+          },
+        ],
+        'task-1',
+        'complete',
+      ),
+    ).toEqual([
+      {
+        id: 'task-1',
+        assetId: 'asset-1',
+        assetName: 'Asset 1',
+        siteName: 'Site 1',
+        dueDate: '2026-05-04T10:00:00.000Z',
+        priority: 'high',
+        status: 'complete',
+        summary: 'Summary 1',
+      },
+      {
+        id: 'task-2',
+        assetId: 'asset-2',
+        assetName: 'Asset 2',
+        siteName: 'Site 2',
+        dueDate: '2026-05-05T10:00:00.000Z',
+        priority: 'low',
+        status: 'pending',
+        summary: 'Summary 2',
+      },
+    ]);
   });
 });

--- a/src/context/AssetGuardProvider.tsx
+++ b/src/context/AssetGuardProvider.tsx
@@ -1,30 +1,64 @@
 import React, {
   createContext,
   PropsWithChildren,
+  useCallback,
   useContext,
   useMemo,
+  useState,
 } from 'react';
 
 import { seedTasks } from '../data/seed';
 import { getTheme, ThemeTokens } from '../theme/tokens';
-import { AppStateSnapshot } from '../types/domain';
+import { AppStateSnapshot, InspectionDraft } from '../types/domain';
+import {
+  InspectionSubmitAction,
+  emptyInspectionDraft,
+  updateTaskStatusForInspectionAction,
+  upsertInspectionDraft,
+} from '../utils/inspectionForm';
 
 interface AssetGuardContextValue {
   snapshot: AppStateSnapshot;
   theme: ThemeTokens;
+  saveInspectionDraft: (taskId: string, draft: InspectionDraft) => void;
+  submitInspectionDraft: (taskId: string, action: InspectionSubmitAction, draft: InspectionDraft) => void;
+  getInspectionDraft: (taskId: string) => InspectionDraft;
 }
 
 const AssetGuardContext = createContext<AssetGuardContextValue | undefined>(undefined);
 
 export function AssetGuardProvider({ children }: PropsWithChildren) {
-  const snapshot = useMemo<AppStateSnapshot>(() => ({
+  const [snapshot, setSnapshot] = useState<AppStateSnapshot>(() => ({
     tasks: seedTasks,
-  }), []);
+    inspectionDrafts: {},
+  }));
+
+  const saveInspectionDraft = useCallback((taskId: string, draft: InspectionDraft) => {
+    setSnapshot((current) => ({
+      ...current,
+      inspectionDrafts: upsertInspectionDraft(current.inspectionDrafts, taskId, draft),
+    }));
+  }, []);
+
+  const submitInspectionDraft = useCallback((taskId: string, action: InspectionSubmitAction, draft: InspectionDraft) => {
+    setSnapshot((current) => ({
+      ...current,
+      tasks: updateTaskStatusForInspectionAction(current.tasks, taskId, action),
+      inspectionDrafts: upsertInspectionDraft(current.inspectionDrafts, taskId, draft),
+    }));
+  }, []);
+
+  const getInspectionDraft = useCallback((taskId: string): InspectionDraft => {
+    return snapshot.inspectionDrafts[taskId] ?? emptyInspectionDraft;
+  }, [snapshot.inspectionDrafts]);
 
   const value = useMemo<AssetGuardContextValue>(() => {
     return {
       snapshot,
       theme: getTheme('light'),
+      saveInspectionDraft,
+      submitInspectionDraft,
+      getInspectionDraft,
     };
   }, [snapshot]);
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -36,7 +36,7 @@ export function HomeScreen({ onSelectTask }: HomeScreenProps) {
             <Text style={[styles.metricLabel, { color: theme.textMuted }]}>Sites</Text>
           </View>
         </View>
-        <Text style={[styles.helper, { color: theme.textMuted }]}>Current scope: dashboard-only. Inspection capture, sync, and auditing are intentionally deferred.</Text>
+        <Text style={[styles.helper, { color: theme.textMuted }]}>Inspection capture is now local-only. Sync and persistence will follow in later iterations.</Text>
       </View>
 
       <Text style={[styles.sectionTitle, { color: theme.text }]}>Scheduled tasks</Text>

--- a/src/screens/InspectionFormScreen.tsx
+++ b/src/screens/InspectionFormScreen.tsx
@@ -19,12 +19,31 @@ interface InspectionFormScreenProps {
 }
 
 export function InspectionFormScreen({ task, onBack }: InspectionFormScreenProps) {
-  const { theme } = useAssetGuard();
-  const [engineerInitials, setEngineerInitials] = React.useState('');
-  const [condition, setCondition] = React.useState<InspectionCondition>('pass');
-  const [notes, setNotes] = React.useState('');
-  const [checklist, setChecklist] = React.useState<InspectionChecklist>(initialInspectionChecklist);
-  const draftSummary = buildInspectionDraftSummary({ engineerInitials, condition, notes, checklist });
+  const { theme, getInspectionDraft, saveInspectionDraft, submitInspectionDraft } = useAssetGuard();
+  const existingDraft = getInspectionDraft(task.id);
+  const [engineerInitials, setEngineerInitials] = React.useState(existingDraft.engineerInitials);
+  const [condition, setCondition] = React.useState<InspectionCondition>(existingDraft.condition);
+  const [notes, setNotes] = React.useState(existingDraft.notes);
+  const [checklist, setChecklist] = React.useState<InspectionChecklist>(existingDraft.checklist ?? initialInspectionChecklist);
+  const currentDraft = React.useMemo(
+    () => ({
+      engineerInitials,
+      condition,
+      notes,
+      checklist,
+    }),
+    [checklist, condition, engineerInitials, notes],
+  );
+  const draftSummary = buildInspectionDraftSummary(currentDraft);
+
+  React.useEffect(() => {
+    saveInspectionDraft(task.id, currentDraft);
+  }, [currentDraft, saveInspectionDraft, task.id]);
+
+  function handleSubmit(action: 'save-draft' | 'complete') {
+    submitInspectionDraft(task.id, action, currentDraft);
+    onBack();
+  }
 
   return (
     <Screen>
@@ -114,6 +133,18 @@ export function InspectionFormScreen({ task, onBack }: InspectionFormScreenProps
         <DetailRow label="Condition" value={draftSummary.condition} />
         <DetailRow label="Checklist complete" value={String(draftSummary.checklistComplete)} />
         <DetailRow label="Notes length" value={String(draftSummary.notesLength)} />
+      </View>
+
+      <View style={styles.actionRow}>
+        <Pressable
+          onPress={() => handleSubmit('save-draft')}
+          style={[styles.secondaryButton, { backgroundColor: theme.surface, borderColor: theme.border }]}
+        >
+          <Text style={[styles.secondaryButtonText, { color: theme.text }]}>Save draft</Text>
+        </Pressable>
+        <Pressable onPress={() => handleSubmit('complete')} style={[styles.primaryButton, { backgroundColor: theme.primary }]}> 
+          <Text style={styles.primaryButtonText}>Complete inspection</Text>
+        </Pressable>
       </View>
     </Screen>
   );
@@ -235,5 +266,35 @@ const styles = StyleSheet.create({
   },
   detailValue: {
     fontSize: 16,
+  },
+  actionRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  secondaryButton: {
+    alignItems: 'center',
+    borderRadius: 16,
+    borderWidth: 1,
+    flex: 1,
+    justifyContent: 'center',
+    minHeight: 52,
+    paddingHorizontal: 16,
+  },
+  secondaryButtonText: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  primaryButton: {
+    alignItems: 'center',
+    borderRadius: 16,
+    flex: 1,
+    justifyContent: 'center',
+    minHeight: 52,
+    paddingHorizontal: 16,
+  },
+  primaryButtonText: {
+    color: '#ffffff',
+    fontSize: 15,
+    fontWeight: '700',
   },
 });

--- a/src/screens/InspectionFormScreen.tsx
+++ b/src/screens/InspectionFormScreen.tsx
@@ -21,18 +21,18 @@ interface InspectionFormScreenProps {
 export function InspectionFormScreen({ task, onBack }: InspectionFormScreenProps) {
   const { theme, getInspectionDraft, saveInspectionDraft, submitInspectionDraft } = useAssetGuard();
   const existingDraft = getInspectionDraft(task.id);
-  const [engineerInitials, setEngineerInitials] = React.useState(existingDraft.engineerInitials);
+  const [employeeNumber, setEmployeeNumber] = React.useState(existingDraft.employeeNumber);
   const [condition, setCondition] = React.useState<InspectionCondition>(existingDraft.condition);
   const [notes, setNotes] = React.useState(existingDraft.notes);
   const [checklist, setChecklist] = React.useState<InspectionChecklist>(existingDraft.checklist ?? initialInspectionChecklist);
   const currentDraft = React.useMemo(
     () => ({
-      engineerInitials,
+      employeeNumber,
       condition,
       notes,
       checklist,
     }),
-    [checklist, condition, engineerInitials, notes],
+    [checklist, condition, employeeNumber, notes],
   );
   const draftSummary = buildInspectionDraftSummary(currentDraft);
 
@@ -66,15 +66,15 @@ export function InspectionFormScreen({ task, onBack }: InspectionFormScreenProps
       </View>
 
       <View style={[styles.card, { backgroundColor: theme.surface, borderColor: theme.border }]}> 
-        <Text style={[styles.sectionTitle, { color: theme.text }]}>Engineer details</Text>
+        <Text style={[styles.sectionTitle, { color: theme.text }]}>Employee details</Text>
         <TextInput
-          autoCapitalize="characters"
-          maxLength={6}
-          onChangeText={setEngineerInitials}
-          placeholder="Engineer initials"
+          keyboardType="number-pad"
+          maxLength={4}
+          onChangeText={(value) => setEmployeeNumber(value.replace(/\D/g, '').slice(0, 4))}
+          placeholder="4-digit employee number"
           placeholderTextColor={theme.textMuted}
           style={[styles.input, { backgroundColor: theme.surfaceMuted, borderColor: theme.border, color: theme.text }]}
-          value={engineerInitials}
+          value={employeeNumber}
         />
       </View>
 
@@ -129,7 +129,8 @@ export function InspectionFormScreen({ task, onBack }: InspectionFormScreenProps
 
       <View style={[styles.card, { backgroundColor: theme.surface, borderColor: theme.border }]}> 
         <Text style={[styles.sectionTitle, { color: theme.text }]}>Current draft</Text>
-        <DetailRow label="Initials" value={draftSummary.engineerInitials} />
+        <DetailRow label="Employee number" value={draftSummary.employeeNumber || 'Not set'} />
+        <DetailRow label="Employee number valid" value={String(draftSummary.employeeNumberValid)} />
         <DetailRow label="Condition" value={draftSummary.condition} />
         <DetailRow label="Checklist complete" value={String(draftSummary.checklistComplete)} />
         <DetailRow label="Notes length" value={String(draftSummary.notesLength)} />

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,5 +1,5 @@
-export type TaskStatus = 'pending' | 'in-progress' | 'complete';
-export type ThemeMode = 'light' | 'dark';
+export type TaskStatus = "pending" | "in-progress" | "complete";
+export type ThemeMode = "light" | "dark";
 
 export interface AssetTask {
   id: string;
@@ -7,11 +7,23 @@ export interface AssetTask {
   assetName: string;
   siteName: string;
   dueDate: string;
-  priority: 'high' | 'medium' | 'low';
+  priority: "high" | "medium" | "low";
   status: TaskStatus;
   summary: string;
 }
 
+export interface InspectionDraft {
+  engineerInitials: string;
+  condition: "pass" | "monitor" | "fail";
+  notes: string;
+  checklist: {
+    safeIsolation: boolean;
+    structuralIntegrity: boolean;
+    leakCheck: boolean;
+  };
+}
+
 export interface AppStateSnapshot {
   tasks: AssetTask[];
+  inspectionDrafts: Record<string, InspectionDraft>;
 }

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -13,7 +13,7 @@ export interface AssetTask {
 }
 
 export interface InspectionDraft {
-  engineerInitials: string;
+  employeeNumber: string;
   condition: "pass" | "monitor" | "fail";
   notes: string;
   checklist: {

--- a/src/utils/inspectionForm.ts
+++ b/src/utils/inspectionForm.ts
@@ -1,3 +1,5 @@
+import { AssetTask, InspectionDraft, TaskStatus } from '../types/domain';
+
 export type InspectionCondition = 'pass' | 'monitor' | 'fail';
 
 export interface InspectionChecklist {
@@ -20,10 +22,19 @@ export interface InspectionDraftSummary {
   checklistComplete: boolean;
 }
 
+export type InspectionSubmitAction = 'save-draft' | 'complete';
+
 export const initialInspectionChecklist: InspectionChecklist = {
   safeIsolation: false,
   structuralIntegrity: false,
   leakCheck: false,
+};
+
+export const emptyInspectionDraft: InspectionDraft = {
+  engineerInitials: '',
+  condition: 'pass',
+  notes: '',
+  checklist: initialInspectionChecklist,
 };
 
 export function normaliseEngineerInitials(value: string): string {
@@ -43,4 +54,36 @@ export function buildInspectionDraftSummary(input: InspectionDraftInput): Inspec
     notesLength: input.notes.trim().length,
     checklistComplete: isInspectionChecklistComplete(input.checklist),
   };
+}
+
+export function upsertInspectionDraft(
+  drafts: Record<string, InspectionDraft>,
+  taskId: string,
+  draft: InspectionDraft,
+): Record<string, InspectionDraft> {
+  return {
+    ...drafts,
+    [taskId]: {
+      engineerInitials: draft.engineerInitials,
+      condition: draft.condition,
+      notes: draft.notes,
+      checklist: {
+        ...draft.checklist,
+      },
+    },
+  };
+}
+
+export function getTaskStatusForInspectionAction(action: InspectionSubmitAction): TaskStatus {
+  return action === 'complete' ? 'complete' : 'in-progress';
+}
+
+export function updateTaskStatusForInspectionAction(
+  tasks: AssetTask[],
+  taskId: string,
+  action: InspectionSubmitAction,
+): AssetTask[] {
+  const nextStatus = getTaskStatusForInspectionAction(action);
+
+  return tasks.map((task) => (task.id === taskId ? { ...task, status: nextStatus } : task));
 }

--- a/src/utils/inspectionForm.ts
+++ b/src/utils/inspectionForm.ts
@@ -9,14 +9,15 @@ export interface InspectionChecklist {
 }
 
 export interface InspectionDraftInput {
-  engineerInitials: string;
+  employeeNumber: string;
   condition: InspectionCondition;
   notes: string;
   checklist: InspectionChecklist;
 }
 
 export interface InspectionDraftSummary {
-  engineerInitials: string;
+  employeeNumber: string;
+  employeeNumberValid: boolean;
   condition: InspectionCondition;
   notesLength: number;
   checklistComplete: boolean;
@@ -31,16 +32,18 @@ export const initialInspectionChecklist: InspectionChecklist = {
 };
 
 export const emptyInspectionDraft: InspectionDraft = {
-  engineerInitials: '',
+  employeeNumber: '',
   condition: 'pass',
   notes: '',
   checklist: initialInspectionChecklist,
 };
 
-export function normaliseEngineerInitials(value: string): string {
-  const trimmed = value.trim().toUpperCase();
+export function normaliseEmployeeNumber(value: string): string {
+  return value.replace(/\D/g, '').slice(0, 4);
+}
 
-  return trimmed || 'Not set';
+export function isValidEmployeeNumber(value: string): boolean {
+  return /^\d{4}$/.test(normaliseEmployeeNumber(value));
 }
 
 export function isInspectionChecklistComplete(checklist: InspectionChecklist): boolean {
@@ -48,8 +51,11 @@ export function isInspectionChecklistComplete(checklist: InspectionChecklist): b
 }
 
 export function buildInspectionDraftSummary(input: InspectionDraftInput): InspectionDraftSummary {
+  const employeeNumber = normaliseEmployeeNumber(input.employeeNumber);
+
   return {
-    engineerInitials: normaliseEngineerInitials(input.engineerInitials),
+    employeeNumber,
+    employeeNumberValid: isValidEmployeeNumber(employeeNumber),
     condition: input.condition,
     notesLength: input.notes.trim().length,
     checklistComplete: isInspectionChecklistComplete(input.checklist),
@@ -64,7 +70,7 @@ export function upsertInspectionDraft(
   return {
     ...drafts,
     [taskId]: {
-      engineerInitials: draft.engineerInitials,
+      employeeNumber: normaliseEmployeeNumber(draft.employeeNumber),
       condition: draft.condition,
       notes: draft.notes,
       checklist: {


### PR DESCRIPTION
Inspection form is now stateful - local app remembers the changes made to the form and will mark tasks as 'complete' once they are. 

Scrapped employee initial identifier and instead request 4 digit employee number - tests changed to reflect this