### PR TITLE
Feat/sync to central db via api

### DIFF
--- a/__tests__/AssetGuardProviderSync.test.ts
+++ b/__tests__/AssetGuardProviderSync.test.ts
@@ -1,0 +1,119 @@
+import React from 'react';
+
+const TestRenderer = require('react-test-renderer');
+const { act } = TestRenderer;
+
+import { AssetGuardProvider, useAssetGuard } from '../src/context/AssetGuardProvider';
+import type { SyncInspectionEntry } from '../src/storage/sqliteStorage';
+
+const mockLoadSnapshotFromDatabase = jest.fn();
+const mockLoadUnsyncedInspectionEntriesFromDatabase = jest.fn();
+const mockMarkInspectionEntriesAsSynced = jest.fn();
+const mockSaveInspectionDraftToDatabase = jest.fn();
+const mockUpdateTaskStatusInDatabase = jest.fn();
+const mockSyncInspectionEntriesToApi = jest.fn();
+
+jest.mock('../src/storage/sqliteStorage', () => ({
+  loadSnapshotFromDatabase: (...args: unknown[]) => mockLoadSnapshotFromDatabase(...args),
+  loadUnsyncedInspectionEntriesFromDatabase: (...args: unknown[]) => mockLoadUnsyncedInspectionEntriesFromDatabase(...args),
+  markInspectionEntriesAsSynced: (...args: unknown[]) => mockMarkInspectionEntriesAsSynced(...args),
+  saveInspectionDraftToDatabase: (...args: unknown[]) => mockSaveInspectionDraftToDatabase(...args),
+  updateTaskStatusInDatabase: (...args: unknown[]) => mockUpdateTaskStatusInDatabase(...args),
+}));
+
+jest.mock('../src/services/sync/syncService', () => ({
+  syncInspectionEntriesToApi: (...args: unknown[]) => mockSyncInspectionEntriesToApi(...args),
+}));
+
+describe('AssetGuardProvider sync flow', () => {
+  const entries: SyncInspectionEntry[] = [
+    {
+      task: {
+        id: 'task-1',
+        asset_id: 'enc:v1:asset-id',
+        asset_name: 'enc:v1:asset-name',
+        site_name: 'enc:v1:site-name',
+        due_date: 'enc:v1:due-date',
+        priority: 'enc:v1:priority',
+        status: 'enc:v1:status',
+        summary: 'enc:v1:summary',
+      },
+      draft: {
+        task_id: 'task-1',
+        employee_number: 'enc:v1:employee-number',
+        condition: 'enc:v1:condition',
+        notes: 'enc:v1:notes',
+        safe_isolation: 'enc:v1:safe-isolation',
+        structural_integrity: 'enc:v1:structural-integrity',
+        leak_check: 'enc:v1:leak-check',
+        is_synced: 0,
+      },
+    },
+  ];
+
+  let capturedContext: ReturnType<typeof useAssetGuard> | undefined;
+
+  function ContextProbe() {
+    capturedContext = useAssetGuard();
+
+    return null;
+  }
+
+  async function renderProvider() {
+    await act(async () => {
+      TestRenderer.create(
+        React.createElement(
+          AssetGuardProvider,
+          null,
+          React.createElement(ContextProbe),
+        ),
+      );
+    });
+  }
+
+  beforeEach(() => {
+    capturedContext = undefined;
+    mockLoadSnapshotFromDatabase.mockReset();
+    mockLoadUnsyncedInspectionEntriesFromDatabase.mockReset();
+    mockMarkInspectionEntriesAsSynced.mockReset();
+    mockSaveInspectionDraftToDatabase.mockReset();
+    mockUpdateTaskStatusInDatabase.mockReset();
+    mockSyncInspectionEntriesToApi.mockReset();
+
+    mockLoadSnapshotFromDatabase.mockResolvedValue({
+      tasks: [],
+      inspectionDrafts: {},
+    });
+  });
+
+  it('marks unsynced rows as synced only after a successful API sync', async () => {
+    mockLoadUnsyncedInspectionEntriesFromDatabase.mockResolvedValue(entries);
+    mockSyncInspectionEntriesToApi.mockResolvedValue(undefined);
+    mockMarkInspectionEntriesAsSynced.mockResolvedValue(undefined);
+
+    await renderProvider();
+
+    let syncedCount = 0;
+
+    await act(async () => {
+      syncedCount = await capturedContext!.syncPendingInspectionEntries();
+    });
+
+    expect(mockSyncInspectionEntriesToApi).toHaveBeenCalledWith(entries);
+    expect(mockMarkInspectionEntriesAsSynced).toHaveBeenCalledWith(['task-1']);
+    expect(mockSyncInspectionEntriesToApi.mock.invocationCallOrder[0]!).toBeLessThan(
+      mockMarkInspectionEntriesAsSynced.mock.invocationCallOrder[0]!,
+    );
+    expect(syncedCount).toBe(1);
+  });
+
+  it('does not mark rows as synced when the API sync fails', async () => {
+    mockLoadUnsyncedInspectionEntriesFromDatabase.mockResolvedValue(entries);
+    mockSyncInspectionEntriesToApi.mockRejectedValue(new Error('Mock sync failed.'));
+
+    await renderProvider();
+
+    await expect(capturedContext!.syncPendingInspectionEntries()).rejects.toThrow('Mock sync failed.');
+    expect(mockMarkInspectionEntriesAsSynced).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/AssetGuardProviderSync.test.ts
+++ b/__tests__/AssetGuardProviderSync.test.ts
@@ -7,6 +7,8 @@ import { AssetGuardProvider, useAssetGuard } from '../src/context/AssetGuardProv
 import type { SyncInspectionEntry } from '../src/storage/sqliteStorage';
 
 const mockLoadSnapshotFromDatabase = jest.fn();
+const mockLoadLastSyncedAtFromDatabase = jest.fn();
+const mockLoadUnsyncedInspectionCountFromDatabase = jest.fn();
 const mockLoadUnsyncedInspectionEntriesFromDatabase = jest.fn();
 const mockMarkInspectionEntriesAsSynced = jest.fn();
 const mockSaveInspectionDraftToDatabase = jest.fn();
@@ -15,6 +17,8 @@ const mockSyncInspectionEntriesToApi = jest.fn();
 
 jest.mock('../src/storage/sqliteStorage', () => ({
   loadSnapshotFromDatabase: (...args: unknown[]) => mockLoadSnapshotFromDatabase(...args),
+  loadLastSyncedAtFromDatabase: (...args: unknown[]) => mockLoadLastSyncedAtFromDatabase(...args),
+  loadUnsyncedInspectionCountFromDatabase: (...args: unknown[]) => mockLoadUnsyncedInspectionCountFromDatabase(...args),
   loadUnsyncedInspectionEntriesFromDatabase: (...args: unknown[]) => mockLoadUnsyncedInspectionEntriesFromDatabase(...args),
   markInspectionEntriesAsSynced: (...args: unknown[]) => mockMarkInspectionEntriesAsSynced(...args),
   saveInspectionDraftToDatabase: (...args: unknown[]) => mockSaveInspectionDraftToDatabase(...args),
@@ -74,6 +78,8 @@ describe('AssetGuardProvider sync flow', () => {
   beforeEach(() => {
     capturedContext = undefined;
     mockLoadSnapshotFromDatabase.mockReset();
+    mockLoadLastSyncedAtFromDatabase.mockReset();
+    mockLoadUnsyncedInspectionCountFromDatabase.mockReset();
     mockLoadUnsyncedInspectionEntriesFromDatabase.mockReset();
     mockMarkInspectionEntriesAsSynced.mockReset();
     mockSaveInspectionDraftToDatabase.mockReset();
@@ -84,12 +90,15 @@ describe('AssetGuardProvider sync flow', () => {
       tasks: [],
       inspectionDrafts: {},
     });
+    mockLoadLastSyncedAtFromDatabase.mockResolvedValue(null);
+    mockLoadUnsyncedInspectionCountFromDatabase.mockResolvedValue(0);
   });
 
   it('marks unsynced rows as synced only after a successful API sync', async () => {
     mockLoadUnsyncedInspectionEntriesFromDatabase.mockResolvedValue(entries);
     mockSyncInspectionEntriesToApi.mockResolvedValue(undefined);
     mockMarkInspectionEntriesAsSynced.mockResolvedValue(undefined);
+    mockLoadUnsyncedInspectionCountFromDatabase.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
 
     await renderProvider();
 

--- a/__tests__/retention.test.ts
+++ b/__tests__/retention.test.ts
@@ -1,20 +1,20 @@
 import { LOCAL_DATA_RETENTION_DAYS, hasLocalDataExpired } from '../src/storage/retention';
 
 describe('local data retention', () => {
-  it('keeps local data when it is newer than the 90 day retention window', () => {
+  it('keeps local data when it is newer than the 30 day retention window', () => {
     expect(
       hasLocalDataExpired(
         '2026-02-05T00:00:00.000Z',
-        new Date('2026-05-04T00:00:00.000Z'),
+        new Date('2026-03-04T00:00:00.000Z'),
       ),
     ).toBe(false);
   });
 
-  it('expires local data once it reaches the 90 day retention window', () => {
+  it('expires local data once it reaches the 30 day retention window', () => {
     expect(
       hasLocalDataExpired(
         '2026-02-03T00:00:00.000Z',
-        new Date('2026-05-04T00:00:00.000Z'),
+        new Date('2026-03-05T00:00:00.000Z'),
       ),
     ).toBe(true);
   });
@@ -24,6 +24,6 @@ describe('local data retention', () => {
   });
 
   it('documents the expected retention policy length', () => {
-    expect(LOCAL_DATA_RETENTION_DAYS).toBe(90);
+    expect(LOCAL_DATA_RETENTION_DAYS).toBe(30);
   });
 });

--- a/__tests__/sqliteMappers.test.ts
+++ b/__tests__/sqliteMappers.test.ts
@@ -35,6 +35,7 @@ describe('sqlite storage mappers', () => {
         safe_isolation: 1,
         structural_integrity: 0,
         leak_check: 1,
+        is_synced: 0,
       }),
     ).toEqual({
       employeeNumber: '1234',
@@ -68,6 +69,7 @@ describe('sqlite storage mappers', () => {
       $safeIsolation: 1,
       $structuralIntegrity: 1,
       $leakCheck: 0,
+      $isSynced: 0,
     });
   });
 });

--- a/__tests__/syncService.test.ts
+++ b/__tests__/syncService.test.ts
@@ -1,0 +1,78 @@
+import type { SyncInspectionEntry } from '../src/storage/sqliteStorage';
+import { MOCK_SYNC_API_URL, syncInspectionEntriesToApi } from '../src/services/sync/syncService';
+
+describe('sync service integration', () => {
+  const fetchMock = jest.fn();
+
+  const entries: SyncInspectionEntry[] = [
+    {
+      task: {
+        id: 'task-1',
+        asset_id: 'enc:v1:asset-id',
+        asset_name: 'enc:v1:asset-name',
+        site_name: 'enc:v1:site-name',
+        due_date: 'enc:v1:due-date',
+        priority: 'enc:v1:priority',
+        status: 'enc:v1:status',
+        summary: 'enc:v1:summary',
+      },
+      draft: {
+        task_id: 'task-1',
+        employee_number: 'enc:v1:employee-number',
+        condition: 'enc:v1:condition',
+        notes: 'enc:v1:notes',
+        safe_isolation: 'enc:v1:safe-isolation',
+        structural_integrity: 'enc:v1:structural-integrity',
+        leak_check: 'enc:v1:leak-check',
+        is_synced: 0,
+      },
+    },
+  ];
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it('posts unsynced inspection entries to the mock backend', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+    });
+
+    await syncInspectionEntriesToApi(entries);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      MOCK_SYNC_API_URL,
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    const request = fetchMock.mock.calls[0]?.[1];
+    const body = JSON.parse(String(request?.body));
+
+    expect(body).toEqual(
+      expect.objectContaining({
+        source: 'AssetGuard',
+        sentAt: expect.any(String),
+        entries,
+      }),
+    );
+  });
+
+  it('throws when the mock backend returns a non-success response', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    await expect(syncInspectionEntriesToApi(entries)).rejects.toThrow(
+      'Sync request failed with status 500.',
+    );
+  });
+});

--- a/__tests__/syncStatus.test.ts
+++ b/__tests__/syncStatus.test.ts
@@ -1,0 +1,15 @@
+import { formatUnsyncedInspectionCount } from '../src/utils/syncStatus';
+
+describe('sync status helpers', () => {
+  it('formats the singular unsynced entry label', () => {
+    expect(formatUnsyncedInspectionCount(1)).toBe('1 unsynced local entry');
+  });
+
+  it('formats the plural unsynced entry label', () => {
+    expect(formatUnsyncedInspectionCount(3)).toBe('3 unsynced local entries');
+  });
+
+  it('formats zero unsynced entries consistently', () => {
+    expect(formatUnsyncedInspectionCount(0)).toBe('0 unsynced local entries');
+  });
+});

--- a/src/context/AssetGuardProvider.tsx
+++ b/src/context/AssetGuardProvider.tsx
@@ -11,7 +11,9 @@ import React, {
 import { getTheme, ThemeTokens } from '../theme/tokens';
 import { AppStateSnapshot, InspectionDraft } from '../types/domain';
 import {
+  loadLastSyncedAtFromDatabase,
   loadSnapshotFromDatabase,
+  loadUnsyncedInspectionCountFromDatabase,
   loadUnsyncedInspectionEntriesFromDatabase,
   markInspectionEntriesAsSynced,
   saveInspectionDraftToDatabase,
@@ -29,6 +31,8 @@ import {
 interface AssetGuardContextValue {
   ready: boolean;
   snapshot: AppStateSnapshot;
+  lastSyncedAt: string | null;
+  unsyncedInspectionCount: number;
   theme: ThemeTokens;
   saveInspectionDraft: (taskId: string, draft: InspectionDraft) => Promise<void>;
   submitInspectionDraft: (taskId: string, action: InspectionSubmitAction, draft: InspectionDraft) => Promise<void>;
@@ -40,6 +44,8 @@ const AssetGuardContext = createContext<AssetGuardContextValue | undefined>(unde
 
 export function AssetGuardProvider({ children }: PropsWithChildren) {
   const [ready, setReady] = useState(false);
+  const [lastSyncedAt, setLastSyncedAt] = useState<string | null>(null);
+  const [unsyncedInspectionCount, setUnsyncedInspectionCount] = useState(0);
   const [snapshot, setSnapshot] = useState<AppStateSnapshot>(() => ({
     tasks: [],
     inspectionDrafts: {},
@@ -51,13 +57,19 @@ export function AssetGuardProvider({ children }: PropsWithChildren) {
     async function bootstrap() {
       try {
         // Load data snapshot from SQLite database on app startup to populate tasks page
-        const nextSnapshot = await loadSnapshotFromDatabase();
+        const [nextSnapshot, nextLastSyncedAt, nextUnsyncedInspectionCount] = await Promise.all([
+          loadSnapshotFromDatabase(),
+          loadLastSyncedAtFromDatabase(),
+          loadUnsyncedInspectionCountFromDatabase(),
+        ]);
 
         if (!active) {
           return;
         }
 
         setSnapshot(nextSnapshot);
+        setLastSyncedAt(nextLastSyncedAt);
+        setUnsyncedInspectionCount(nextUnsyncedInspectionCount);
       } finally {
         if (active) {
           setReady(true);
@@ -79,6 +91,7 @@ export function AssetGuardProvider({ children }: PropsWithChildren) {
     }));
 
     await saveInspectionDraftToDatabase(taskId, draft);
+    setUnsyncedInspectionCount(await loadUnsyncedInspectionCountFromDatabase());
   }, []);
 
   const submitInspectionDraft = useCallback(async (taskId: string, action: InspectionSubmitAction, draft: InspectionDraft) => {
@@ -92,6 +105,7 @@ export function AssetGuardProvider({ children }: PropsWithChildren) {
 
     await saveInspectionDraftToDatabase(taskId, draft);
     await updateTaskStatusInDatabase(taskId, nextStatus);
+    setUnsyncedInspectionCount(await loadUnsyncedInspectionCountFromDatabase());
   }, []);
 
   const getInspectionDraft = useCallback((taskId: string): InspectionDraft => {
@@ -108,6 +122,9 @@ export function AssetGuardProvider({ children }: PropsWithChildren) {
     await syncInspectionEntriesToApi(unsyncedEntries);
     await markInspectionEntriesAsSynced(unsyncedEntries.map((entry) => entry.draft.task_id));
 
+    setLastSyncedAt(new Date().toISOString());
+    setUnsyncedInspectionCount(await loadUnsyncedInspectionCountFromDatabase());
+
     return unsyncedEntries.length;
   }, []);
 
@@ -115,13 +132,15 @@ export function AssetGuardProvider({ children }: PropsWithChildren) {
     return {
       ready,
       snapshot,
+      lastSyncedAt,
+      unsyncedInspectionCount,
       theme: getTheme('light'),
       saveInspectionDraft,
       submitInspectionDraft,
       getInspectionDraft,
       syncPendingInspectionEntries,
     };
-  }, [getInspectionDraft, ready, saveInspectionDraft, snapshot, submitInspectionDraft, syncPendingInspectionEntries]);
+  }, [getInspectionDraft, lastSyncedAt, ready, saveInspectionDraft, snapshot, submitInspectionDraft, syncPendingInspectionEntries, unsyncedInspectionCount]);
 
   return <AssetGuardContext.Provider value={value}>{children}</AssetGuardContext.Provider>;
 }

--- a/src/context/AssetGuardProvider.tsx
+++ b/src/context/AssetGuardProvider.tsx
@@ -12,9 +12,12 @@ import { getTheme, ThemeTokens } from '../theme/tokens';
 import { AppStateSnapshot, InspectionDraft } from '../types/domain';
 import {
   loadSnapshotFromDatabase,
+  loadUnsyncedInspectionEntriesFromDatabase,
+  markInspectionEntriesAsSynced,
   saveInspectionDraftToDatabase,
   updateTaskStatusInDatabase,
 } from '../storage/sqliteStorage';
+import { syncInspectionEntriesToApi } from '../services/sync/syncService';
 import {
   InspectionSubmitAction,
   emptyInspectionDraft,
@@ -30,6 +33,7 @@ interface AssetGuardContextValue {
   saveInspectionDraft: (taskId: string, draft: InspectionDraft) => Promise<void>;
   submitInspectionDraft: (taskId: string, action: InspectionSubmitAction, draft: InspectionDraft) => Promise<void>;
   getInspectionDraft: (taskId: string) => InspectionDraft;
+  syncPendingInspectionEntries: () => Promise<number>;
 }
 
 const AssetGuardContext = createContext<AssetGuardContextValue | undefined>(undefined);
@@ -94,6 +98,19 @@ export function AssetGuardProvider({ children }: PropsWithChildren) {
     return snapshot.inspectionDrafts[taskId] ?? emptyInspectionDraft;
   }, [snapshot.inspectionDrafts]);
 
+  const syncPendingInspectionEntries = useCallback(async () => {
+    const unsyncedEntries = await loadUnsyncedInspectionEntriesFromDatabase();
+
+    if (unsyncedEntries.length === 0) {
+      return 0;
+    }
+
+    await syncInspectionEntriesToApi(unsyncedEntries);
+    await markInspectionEntriesAsSynced(unsyncedEntries.map((entry) => entry.draft.task_id));
+
+    return unsyncedEntries.length;
+  }, []);
+
   const value = useMemo<AssetGuardContextValue>(() => {
     return {
       ready,
@@ -102,8 +119,9 @@ export function AssetGuardProvider({ children }: PropsWithChildren) {
       saveInspectionDraft,
       submitInspectionDraft,
       getInspectionDraft,
+      syncPendingInspectionEntries,
     };
-  }, [getInspectionDraft, ready, saveInspectionDraft, snapshot, submitInspectionDraft]);
+  }, [getInspectionDraft, ready, saveInspectionDraft, snapshot, submitInspectionDraft, syncPendingInspectionEntries]);
 
   return <AssetGuardContext.Provider value={value}>{children}</AssetGuardContext.Provider>;
 }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -4,8 +4,8 @@ import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Screen } from '../components/Screen';
 import { StatusBadge } from '../components/StatusBadge';
 import { useAssetGuard, useSnapshotData } from '../context/AssetGuardProvider';
-import { MOCK_SYNC_API_URL } from '../services/sync/syncService';
 import { loadDatabaseDebugView } from '../storage/sqliteStorage';
+import { formatUnsyncedInspectionCount } from '../utils/syncStatus';
 
 import { formatShortDate } from '../utils/date';
 
@@ -14,7 +14,7 @@ interface HomeScreenProps {
 }
 
 export function HomeScreen({ onSelectTask }: HomeScreenProps) {
-  const { theme, syncPendingInspectionEntries } = useAssetGuard();
+  const { theme, syncPendingInspectionEntries, lastSyncedAt, unsyncedInspectionCount } = useAssetGuard();
   const { tasks } = useSnapshotData();
   const [databasePreview, setDatabasePreview] = useState<string | null>(null);
   const [debugError, setDebugError] = useState<string | null>(null);
@@ -24,6 +24,7 @@ export function HomeScreen({ onSelectTask }: HomeScreenProps) {
   const [isSyncing, setIsSyncing] = useState(false);
   const highPriorityCount = tasks.filter((task) => task.priority === 'high').length;
   const uniqueSiteCount = new Set(tasks.map((task) => task.siteName)).size;
+  const lastSyncedLabel = lastSyncedAt ? new Date(lastSyncedAt).toLocaleString() : 'Never';
 
   async function handleViewLocalDatabase() {
     try {
@@ -94,7 +95,8 @@ export function HomeScreen({ onSelectTask }: HomeScreenProps) {
           >
             <Text style={styles.syncButtonLabel}>{isSyncing ? 'Syncing...' : 'Sync to backend API'}</Text>
           </Pressable>
-          <Text style={[styles.helper, { color: theme.textMuted }]}>Placeholder endpoint: {MOCK_SYNC_API_URL}</Text>
+          <Text style={[styles.helper, { color: theme.textMuted }]}>{formatUnsyncedInspectionCount(unsyncedInspectionCount)}</Text>
+          <Text style={[styles.helper, { color: theme.textMuted }]}>Last synced data at: {lastSyncedLabel}</Text>
           {syncStatusMessage ? (
             <Text style={[styles.syncStatus, { color: theme.text }]}>{syncStatusMessage}</Text>
           ) : null}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -4,6 +4,7 @@ import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Screen } from '../components/Screen';
 import { StatusBadge } from '../components/StatusBadge';
 import { useAssetGuard, useSnapshotData } from '../context/AssetGuardProvider';
+import { MOCK_SYNC_API_URL } from '../services/sync/syncService';
 import { loadDatabaseDebugView } from '../storage/sqliteStorage';
 
 import { formatShortDate } from '../utils/date';
@@ -13,11 +14,14 @@ interface HomeScreenProps {
 }
 
 export function HomeScreen({ onSelectTask }: HomeScreenProps) {
-  const { theme } = useAssetGuard();
+  const { theme, syncPendingInspectionEntries } = useAssetGuard();
   const { tasks } = useSnapshotData();
   const [databasePreview, setDatabasePreview] = useState<string | null>(null);
   const [debugError, setDebugError] = useState<string | null>(null);
   const [isLoadingDatabasePreview, setIsLoadingDatabasePreview] = useState(false);
+  const [syncStatusMessage, setSyncStatusMessage] = useState<string | null>(null);
+  const [syncError, setSyncError] = useState<string | null>(null);
+  const [isSyncing, setIsSyncing] = useState(false);
   const highPriorityCount = tasks.filter((task) => task.priority === 'high').length;
   const uniqueSiteCount = new Set(tasks.map((task) => task.siteName)).size;
 
@@ -41,6 +45,28 @@ export function HomeScreen({ onSelectTask }: HomeScreenProps) {
     }
   }
 
+  async function handleSyncToBackend() {
+    try {
+      setIsSyncing(true);
+      setSyncError(null);
+
+      const syncedEntryCount = await syncPendingInspectionEntries();
+
+      if (syncedEntryCount === 0) {
+        setSyncStatusMessage('No unsynced local inspection entries were found.');
+      } else {
+        setSyncStatusMessage(`Synced ${syncedEntryCount} entr${syncedEntryCount === 1 ? 'y' : 'ies'} to the placeholder backend.`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to sync local inspection data.';
+
+      setSyncError(message);
+      setSyncStatusMessage(null);
+    } finally {
+      setIsSyncing(false);
+    }
+  }
+
   return (
     <Screen>
       <View style={[styles.hero, { backgroundColor: theme.surface, borderColor: theme.border }]}> 
@@ -60,7 +86,22 @@ export function HomeScreen({ onSelectTask }: HomeScreenProps) {
             <Text style={[styles.metricLabel, { color: theme.textMuted }]}>Sites</Text>
           </View>
         </View>
-        <Text style={[styles.helper, { color: theme.textMuted }]}>Inspection capture is now local-only. Sync and persistence will follow in later iterations.</Text>
+        <Text style={[styles.helper, { color: theme.textMuted }]}>Inspection capture is stored locally first, then posted to a placeholder backend when you trigger sync.</Text>
+        <View style={styles.syncSection}>
+          <Pressable
+            onPress={() => { void handleSyncToBackend(); }}
+            style={[styles.syncButton, { backgroundColor: theme.primary }]}
+          >
+            <Text style={styles.syncButtonLabel}>{isSyncing ? 'Syncing...' : 'Sync to backend API'}</Text>
+          </Pressable>
+          <Text style={[styles.helper, { color: theme.textMuted }]}>Placeholder endpoint: {MOCK_SYNC_API_URL}</Text>
+          {syncStatusMessage ? (
+            <Text style={[styles.syncStatus, { color: theme.text }]}>{syncStatusMessage}</Text>
+          ) : null}
+          {syncError ? (
+            <Text style={[styles.debugError, { color: theme.danger }]}>Sync error: {syncError}</Text>
+          ) : null}
+        </View>
         {__DEV__ ? (
           <View style={styles.debugSection}>
             <Pressable
@@ -178,6 +219,24 @@ const styles = StyleSheet.create({
   debugSection: {
     gap: 10,
     marginTop: 4,
+  },
+  syncButton: {
+    borderRadius: 14,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  syncButtonLabel: {
+    color: '#ffffff',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  syncSection: {
+    gap: 10,
+    marginTop: 4,
+  },
+  syncStatus: {
+    fontSize: 13,
+    lineHeight: 18,
   },
   sectionTitle: {
     fontSize: 20,

--- a/src/services/sync/syncService.ts
+++ b/src/services/sync/syncService.ts
@@ -1,0 +1,21 @@
+import type { SyncInspectionEntry } from '../../storage/sqliteStorage';
+
+export const MOCK_SYNC_API_URL = 'https://postman-echo.com/post';
+
+export async function syncInspectionEntriesToApi(entries: SyncInspectionEntry[]): Promise<void> {
+  const response = await fetch(MOCK_SYNC_API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      source: 'AssetGuard',
+      sentAt: new Date().toISOString(),
+      entries,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Sync request failed with status ${response.status}.`);
+  }
+}

--- a/src/storage/sqliteMappers.ts
+++ b/src/storage/sqliteMappers.ts
@@ -25,6 +25,7 @@ export interface DraftRow {
   safe_isolation: number;
   structural_integrity: number;
   leak_check: number;
+  is_synced: number;
 }
 
 export function rowToTask(row: TaskRow): AssetTask {
@@ -62,5 +63,6 @@ export function draftToSqliteParams(taskId: string, draft: InspectionDraft) {
     $safeIsolation: draft.checklist.safeIsolation ? 1 : 0,
     $structuralIntegrity: draft.checklist.structuralIntegrity ? 1 : 0,
     $leakCheck: draft.checklist.leakCheck ? 1 : 0,
+    $isSynced: 0,
   };
 }

--- a/src/storage/sqliteStorage.ts
+++ b/src/storage/sqliteStorage.ts
@@ -19,6 +19,7 @@ It seeds data from src/data/seed.ts for PoC purposes
 
 const DATABASE_NAME = 'assetguard.db';
 const LOCAL_DATA_LAST_UPDATED_KEY = 'local_data_last_updated_at';
+const LAST_SYNCED_AT_KEY = 'last_synced_at';
 
 type StoredValue = string | number;
 
@@ -78,6 +79,10 @@ interface DatabaseTransaction {
 
 interface MetadataRow {
   value: string;
+}
+
+interface CountRow {
+  count: number;
 }
 
 let databasePromise: Promise<SQLite.SQLiteDatabase> | null = null;
@@ -161,6 +166,15 @@ async function getLocalDataLastUpdatedAt(db: SQLite.SQLiteDatabase) {
   return row?.value ?? null;
 }
 
+async function getMetadataValue(db: SQLite.SQLiteDatabase, key: string) {
+  const row = await db.getFirstAsync<MetadataRow>(
+    'SELECT value FROM app_metadata WHERE key = $key',
+    { $key: key },
+  );
+
+  return row?.value ?? null;
+}
+
 async function updateLocalDataRetentionMarker(target: DatabaseTransaction | SQLite.SQLiteDatabase, timestamp = new Date().toISOString()) {
   await target.runAsync(
     `INSERT INTO app_metadata (key, value)
@@ -168,6 +182,18 @@ async function updateLocalDataRetentionMarker(target: DatabaseTransaction | SQLi
      ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
     {
       $key: LOCAL_DATA_LAST_UPDATED_KEY,
+      $value: timestamp,
+    },
+  );
+}
+
+async function updateLastSyncedAt(target: DatabaseTransaction | SQLite.SQLiteDatabase, timestamp = new Date().toISOString()) {
+  await target.runAsync(
+    `INSERT INTO app_metadata (key, value)
+     VALUES ($key, $value)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+    {
+      $key: LAST_SYNCED_AT_KEY,
       $value: timestamp,
     },
   );
@@ -541,6 +567,17 @@ export async function loadUnsyncedInspectionEntriesFromDatabase(): Promise<SyncI
   });
 }
 
+export async function loadUnsyncedInspectionCountFromDatabase(): Promise<number> {
+  const db = await ensureDatabaseReady();
+  const row = await db.getFirstAsync<CountRow>(
+    `SELECT COUNT(*) AS count
+     FROM inspection_drafts
+     WHERE is_synced = 0`,
+  );
+
+  return row?.count ?? 0;
+}
+
 export async function markInspectionEntriesAsSynced(taskIds: string[]): Promise<void> {
   if (taskIds.length === 0) {
     return;
@@ -556,5 +593,12 @@ export async function markInspectionEntriesAsSynced(taskIds: string[]): Promise<
     ...taskIds,
   );
 
+  await updateLastSyncedAt(db);
   await updateLocalDataRetentionMarker(db);
+}
+
+export async function loadLastSyncedAtFromDatabase(): Promise<string | null> {
+  const db = await ensureDatabaseReady();
+
+  return await getMetadataValue(db, LAST_SYNCED_AT_KEY);
 }

--- a/src/storage/sqliteStorage.ts
+++ b/src/storage/sqliteStorage.ts
@@ -22,6 +22,10 @@ const LOCAL_DATA_LAST_UPDATED_KEY = 'local_data_last_updated_at';
 
 type StoredValue = string | number;
 
+interface TableInfoRow {
+  name: string;
+}
+
 interface StoredTaskRow {
   id: string;
   asset_id: StoredValue;
@@ -41,6 +45,30 @@ interface StoredDraftRow {
   safe_isolation: StoredValue;
   structural_integrity: StoredValue;
   leak_check: StoredValue;
+  is_synced: number;
+}
+
+export interface SyncInspectionEntry {
+  task: {
+    id: string;
+    asset_id: string | number;
+    asset_name: string | number;
+    site_name: string | number;
+    due_date: string | number;
+    priority: string | number;
+    status: string | number;
+    summary: string | number;
+  };
+  draft: {
+    task_id: string;
+    employee_number: string | number;
+    condition: string | number;
+    notes: string | number;
+    safe_isolation: string | number;
+    structural_integrity: string | number;
+    leak_check: string | number;
+    is_synced: number;
+  };
 }
 
 interface DatabaseTransaction {
@@ -100,9 +128,12 @@ async function initialiseDatabase(db: SQLite.SQLiteDatabase) {
       safe_isolation INTEGER NOT NULL,
       structural_integrity INTEGER NOT NULL,
       leak_check INTEGER NOT NULL,
+      is_synced INTEGER NOT NULL DEFAULT 0,
       FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE
     );
   `);
+
+  await ensureDraftSyncColumn(db);
 
   await purgeExpiredLocalDataIfNeeded(db);
 
@@ -160,6 +191,16 @@ async function purgeExpiredLocalDataIfNeeded(db: SQLite.SQLiteDatabase) {
   }
 
   await resetDatabaseWithEncryptedSeedData(db);
+}
+
+async function ensureDraftSyncColumn(db: SQLite.SQLiteDatabase) {
+  const columns = await db.getAllAsync<TableInfoRow>('PRAGMA table_info(inspection_drafts)');
+
+  if (columns.some((column) => column.name === 'is_synced')) {
+    return;
+  }
+
+  await db.execAsync('ALTER TABLE inspection_drafts ADD COLUMN is_synced INTEGER NOT NULL DEFAULT 0;');
 }
 
 async function seedEncryptedTasks(txn: DatabaseTransaction) {
@@ -223,6 +264,7 @@ async function decryptDraftRow(row: StoredDraftRow): Promise<DraftRow> {
     safe_isolation: await decryptStorageNumber(row.safe_isolation),
     structural_integrity: await decryptStorageNumber(row.structural_integrity),
     leak_check: await decryptStorageNumber(row.leak_check),
+    is_synced: row.is_synced,
   };
 }
 
@@ -291,7 +333,7 @@ async function migratePlaintextRowsToEncrypted(db: SQLite.SQLiteDatabase) {
      FROM tasks`,
   );
   const draftRows = await db.getAllAsync<StoredDraftRow>(
-    `SELECT task_id, employee_number, condition, notes, safe_isolation, structural_integrity, leak_check
+    `SELECT task_id, employee_number, condition, notes, safe_isolation, structural_integrity, leak_check, is_synced
      FROM inspection_drafts`,
   );
 
@@ -335,7 +377,8 @@ async function migratePlaintextRowsToEncrypted(db: SQLite.SQLiteDatabase) {
              notes = $notes,
              safe_isolation = $safeIsolation,
              structural_integrity = $structuralIntegrity,
-             leak_check = $leakCheck
+             leak_check = $leakCheck,
+             is_synced = $isSynced
          WHERE task_id = $taskId`,
         {
           $taskId: row.task_id,
@@ -345,6 +388,7 @@ async function migratePlaintextRowsToEncrypted(db: SQLite.SQLiteDatabase) {
           $safeIsolation: await encryptValueIfNeeded(row.safe_isolation),
           $structuralIntegrity: await encryptValueIfNeeded(row.structural_integrity),
           $leakCheck: await encryptValueIfNeeded(row.leak_check),
+          $isSynced: row.is_synced,
         },
       );
     }
@@ -359,7 +403,7 @@ export async function loadSnapshotFromDatabase(): Promise<AppStateSnapshot> {
      ORDER BY id ASC`,
   );
   const draftRows = await db.getAllAsync<StoredDraftRow>(
-    `SELECT task_id, employee_number, condition, notes, safe_isolation, structural_integrity, leak_check
+    `SELECT task_id, employee_number, condition, notes, safe_isolation, structural_integrity, leak_check, is_synced
      FROM inspection_drafts`,
   );
 
@@ -401,7 +445,8 @@ export async function saveInspectionDraftToDatabase(taskId: string, draft: Inspe
        notes,
        safe_isolation,
        structural_integrity,
-       leak_check
+       leak_check,
+       is_synced
      ) VALUES (
        $taskId,
        $employeeNumber,
@@ -409,7 +454,8 @@ export async function saveInspectionDraftToDatabase(taskId: string, draft: Inspe
        $notes,
        $safeIsolation,
        $structuralIntegrity,
-       $leakCheck
+       $leakCheck,
+       $isSynced
      )
      ON CONFLICT(task_id) DO UPDATE SET
        employee_number = excluded.employee_number,
@@ -417,7 +463,8 @@ export async function saveInspectionDraftToDatabase(taskId: string, draft: Inspe
        notes = excluded.notes,
        safe_isolation = excluded.safe_isolation,
        structural_integrity = excluded.structural_integrity,
-       leak_check = excluded.leak_check`,
+       leak_check = excluded.leak_check,
+       is_synced = excluded.is_synced`,
     encryptedDraftParams,
   );
 
@@ -444,7 +491,7 @@ export async function loadDatabaseDebugView() {
      ORDER BY id ASC`,
   );
   const inspectionDrafts = await db.getAllAsync<StoredDraftRow>(
-    `SELECT task_id, employee_number, condition, notes, safe_isolation, structural_integrity, leak_check
+    `SELECT task_id, employee_number, condition, notes, safe_isolation, structural_integrity, leak_check, is_synced
      FROM inspection_drafts
      ORDER BY task_id ASC`,
   );
@@ -454,4 +501,59 @@ export async function loadDatabaseDebugView() {
     tasks,
     inspectionDrafts,
   };
+}
+
+export async function loadUnsyncedInspectionEntriesFromDatabase(): Promise<SyncInspectionEntry[]> {
+  const db = await ensureDatabaseReady();
+  const draftRows = await db.getAllAsync<StoredDraftRow>(
+    `SELECT task_id, employee_number, condition, notes, safe_isolation, structural_integrity, leak_check, is_synced
+     FROM inspection_drafts
+     WHERE is_synced = 0
+     ORDER BY task_id ASC`,
+  );
+
+  if (draftRows.length === 0) {
+    return [];
+  }
+
+  const taskIds = draftRows.map((row) => row.task_id);
+  const placeholders = taskIds.map(() => '?').join(', ');
+  const taskRows = await db.getAllAsync<StoredTaskRow>(
+    `SELECT id, asset_id, asset_name, site_name, due_date, priority, status, summary
+     FROM tasks
+     WHERE id IN (${placeholders})`,
+    ...taskIds,
+  );
+  const taskMap = new Map(taskRows.map((row) => [row.id, row]));
+
+  return draftRows.flatMap((draftRow) => {
+    const taskRow = taskMap.get(draftRow.task_id);
+
+    if (!taskRow) {
+      return [];
+    }
+
+    return [{
+      task: taskRow,
+      draft: draftRow,
+    }];
+  });
+}
+
+export async function markInspectionEntriesAsSynced(taskIds: string[]): Promise<void> {
+  if (taskIds.length === 0) {
+    return;
+  }
+
+  const db = await ensureDatabaseReady();
+  const placeholders = taskIds.map(() => '?').join(', ');
+
+  await db.runAsync(
+    `UPDATE inspection_drafts
+     SET is_synced = 1
+     WHERE task_id IN (${placeholders})`,
+    ...taskIds,
+  );
+
+  await updateLocalDataRetentionMarker(db);
 }

--- a/src/storage/sqliteStorage.ts
+++ b/src/storage/sqliteStorage.ts
@@ -301,6 +301,7 @@ async function encryptDraftParams(taskId: string, draft: InspectionDraft) {
     $safeIsolation: await encryptStorageValue(plaintextParams.$safeIsolation),
     $structuralIntegrity: await encryptStorageValue(plaintextParams.$structuralIntegrity),
     $leakCheck: await encryptStorageValue(plaintextParams.$leakCheck),
+    $isSynced: plaintextParams.$isSynced,
   };
 }
 

--- a/src/utils/syncStatus.ts
+++ b/src/utils/syncStatus.ts
@@ -1,0 +1,3 @@
+export function formatUnsyncedInspectionCount(count: number) {
+  return `${count} unsynced local entr${count === 1 ? 'y' : 'ies'}`;
+}


### PR DESCRIPTION
Sync button sends (MOCK) API request to (MOCK) sync to backend database

Home page now displays information around last sync and number of unsynced items

Added unit tests around this